### PR TITLE
Fixes #6: Version specified in `_version.py`

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Get package version
         id: getversion
         run: |
-           VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml)
+           VERSION=$(sed -n 's/^__version__ = "\(.*\)"/\1/p' mpython/_version.py)
            echo "pyproject.toml version: $VERSION"
            git config user.name github-actions
            git config user.email github-actions@github.com

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     paths:
-      - pyproject.toml
+      - mpython/_version.py
 
 jobs:
   create-tag:

--- a/mpython/__init__.py
+++ b/mpython/__init__.py
@@ -5,6 +5,7 @@ from .matlab_function import MatlabFunction
 from .runtime import Runtime
 from .sparse_array import SparseArray
 from .struct import Struct
+from ._version import __version__
 
 __all__ = [
     "Runtime",
@@ -14,6 +15,7 @@ __all__ = [
     "Struct",
     "Array",
     "SparseArray",
+    "__version__",
 ]
 
 # ----------------------------------------------------------------------

--- a/mpython/_version.py
+++ b/mpython/_version.py
@@ -1,0 +1,1 @@
+__version__ = "25.04alpha2.post2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mpython-core"
-version = "25.04alpha2.post2"
+dynamic = ["version"]
 description = "Core Python elements for wrapped MPython packages."
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -23,6 +23,9 @@ classifiers = [
 dependencies = [
     "numpy"
 ]
+
+[tool.setuptools.dynamic]
+version = {attr = "mpython._version.__version__"}
 
 [project.urls]
 Repository = "https://github.com/MPython-Package-Factory/mpython-core"


### PR DESCRIPTION
This adds a new `_version.py` file in `mpython`, that is used to set the version field in `pyproject.toml`. Update to version number will trigger the `publish-to-pypi` workflow, creating a tag for that version and releasing the version on PyPI.  