### PR TITLE
DOC: Explicit 3.13 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pip install mpython-core
 
 ## Requirements
 
-- Python 3.9 - 3.12
+- Python 3.9 - 3.13
 - MATLAB Runtime (if MATLAB is not installed)
 - NumPy
 - Optional: SciPy (for sparse matrix support)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "mpython-core"
 dynamic = ["version"]
 description = "Core Python elements for wrapped MPython packages."
 readme = "README.md"
+
 license = {file = "LICENSE"}
 authors = [
   {name = "Johan Medrano", email = "johan.medrano@ucl.ac.uk"},
@@ -36,6 +37,7 @@ version = {attr = "mpython._version.__version__"}
 
 [project.urls]
 Repository = "https://github.com/MPython-Package-Factory/mpython-core"
+Homepage = "https://github.com/MPython-Package-Factory/mpython-core"
 
 [tool.setuptools.packages]
 find = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "numpy"


### PR DESCRIPTION
Tiny little doc update to make it clear 3.13 is supported (to the extent that MATLAB supports it, which I actually don't know!). But this is at least consistent with the version pin from 37a772 of `<3.14`.

Closes #4