### PR TITLE
ENH: do not explicitly import spm._spm 

### DIFF
--- a/mpython/array.py
+++ b/mpython/array.py
@@ -1,7 +1,11 @@
 import numpy as np
 
 from .core import WrappedArray, _ListishMixin
-from .utils import _copy_if_needed
+from .utils import _copy_if_needed, DelayedImport
+
+
+class _imports(DelayedImport):
+    Cell = 'mpython.cell.Cell'
 
 
 class Array(_ListishMixin, WrappedArray):
@@ -48,7 +52,7 @@ class Array(_ListishMixin, WrappedArray):
         return np.ndarray.view(self, np.ndarray)
 
     @classmethod
-    def _from_runtime(cls, other) -> "Array":
+    def _from_runtime(cls, other, runtime=None) -> "Array":
         other = np.asarray(other)
         if len(other.shape) == 2 and other.shape[0] == 1:
             other = other.squeeze(0)
@@ -176,7 +180,7 @@ class Array(_ListishMixin, WrappedArray):
         array : Array
             Converted array.
         """
-        from .cell import Cell  # FIXME: avoid circular import
+        Cell = _imports.Cell
 
         if not isinstance(other, Cell):
             raise TypeError(f"Expected a {Cell} but got a {type(other)}")

--- a/mpython/cell.py
+++ b/mpython/cell.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from .core import AnyDelayedArray, DelayedCell, MatlabType, WrappedArray, _ListMixin
-from .utils import _copy_if_needed, _empty_array, _import_matlab, _matlab_array_types
-
-global matlab
+from .core import (
+    AnyDelayedArray, DelayedCell, MatlabType, WrappedArray, _ListMixin
+)
+from .utils import _copy_if_needed, _empty_array, _matlab_array_types
 
 
 class Cell(_ListMixin, WrappedArray):
@@ -67,7 +67,8 @@ class Cell(_ListMixin, WrappedArray):
     def _DEFAULT(cls, shape: list = ()) -> np.ndarray:
         data = np.empty(shape, dtype=object)
         opt = dict(
-            flags=["refs_ok", "zerosize_ok"], op_flags=["writeonly", "no_broadcast"]
+            flags=["refs_ok", "zerosize_ok"],
+            op_flags=["writeonly", "no_broadcast"]
         )
         with np.nditer(data, **opt) as iter:
             for elem in iter:
@@ -77,7 +78,8 @@ class Cell(_ListMixin, WrappedArray):
     def _fill_default(self):
         arr = np.ndarray.view(self, np.ndarray)
         opt = dict(
-            flags=["refs_ok", "zerosize_ok"], op_flags=["writeonly", "no_broadcast"]
+            flags=["refs_ok", "zerosize_ok"],
+            op_flags=["writeonly", "no_broadcast"]
         )
         with np.nditer(arr, **opt) as iter:
             for elem in iter:
@@ -106,7 +108,7 @@ class Cell(_ListMixin, WrappedArray):
             return dict(type__="cell", size__=size, data__=data)
 
     @classmethod
-    def _from_runtime(cls, objdict: dict) -> "Cell":
+    def _from_runtime(cls, objdict: dict, runtime=None) -> "Cell":
         if isinstance(objdict, (list, tuple, set)):
             shape = [len(objdict)]
             objdict = dict(type__="cell", size__=shape, data__=objdict)
@@ -126,16 +128,18 @@ class Cell(_ListMixin, WrappedArray):
             obj = data.view(cls)
         except Exception:
             raise RuntimeError(
-                f"Failed to construct Cell data:\n  data={data}\n  objdict={objdict}"
+                f"Failed to construct Cell data:\n"
+                f"  data={data}\n  objdict={objdict}"
             )
 
         # recurse
         opt = dict(
-            flags=["refs_ok", "zerosize_ok"], op_flags=["readwrite", "no_broadcast"]
+            flags=["refs_ok", "zerosize_ok"],
+            op_flags=["readwrite", "no_broadcast"]
         )
         with np.nditer(data, **opt) as iter:
             for elem in iter:
-                elem[()] = MatlabType._from_runtime(elem.item())
+                elem[()] = MatlabType._from_runtime(elem.item(), runtime)
 
         return obj
 
@@ -217,10 +221,6 @@ class Cell(_ListMixin, WrappedArray):
 
         # recursive shallow conversion
         if not deepcat:
-            # make sure matlab is imported so that we can detect
-            # matlab arrays.
-            _import_matlab()
-
             # This is so list[list] are converted to Cell[Cell] and
             # not to a 2D Cell array.
             def asrecursive(other):
@@ -266,7 +266,8 @@ class Cell(_ListMixin, WrappedArray):
 
         # recurse
         opt = dict(
-            flags=["refs_ok", "zerosize_ok"], op_flags=["readwrite", "no_broadcast"]
+            flags=["refs_ok", "zerosize_ok"],
+            op_flags=["readwrite", "no_broadcast"]
         )
         with np.nditer(other, **opt) as iter:
             for elem in iter:
@@ -286,7 +287,8 @@ class Cell(_ListMixin, WrappedArray):
         rebuild = False
         arr = np.asarray(arr)
         opt = dict(
-            flags=["refs_ok", "zerosize_ok"], op_flags=["readwrite", "no_broadcast"]
+            flags=["refs_ok", "zerosize_ok"],
+            op_flags=["readwrite", "no_broadcast"]
         )
         with np.nditer(arr, **opt) as iter:
             for elem in iter:

--- a/mpython/core/base_types.py
+++ b/mpython/core/base_types.py
@@ -2,7 +2,17 @@ from functools import partial
 
 import numpy as np
 
-from ..utils import _import_matlab, _matlab_array_types
+from ..utils import _import_matlab, _matlab_array_types, DelayedImport
+
+
+class _imports(DelayedImport):
+    Array = 'mpython.array.Array'
+    Cell = 'mpython.cell.Cell'
+    Struct = 'mpython.struct.Struct'
+    SparseArray = 'mpython.sparse_array.SparseArray'
+    MatlabClass = 'mpython.matlab_class.MatlabClass'
+    MatlabFunction = 'mpython.matlab_function.MatlabFunction'
+    AnyDelayedArray = 'mpython.core.delayed_types.MatlabFunction'
 
 
 class MatlabType:
@@ -16,16 +26,14 @@ class MatlabType:
 
         !!! warning "Conversion is performed in-place when possible."
         """
-        # FIXME: Circular import
-        from ..array import Array
-
-        # FIXME: Circular import
-        from ..cell import Cell
-        from ..matlab_class import MatlabClass
-        from ..matlab_function import MatlabFunction
-        from ..sparse_array import SparseArray
-        from ..struct import Struct
-        from .delayed_types import AnyDelayedArray
+        # Circular import
+        Array = _imports.Array
+        Cell = _imports.Cell
+        MatlabClass = _imports.MatlabClass
+        MatlabFunction = _imports.MatlabFunction
+        SparseArray = _imports.SparseArray
+        Struct = _imports.Struct
+        AnyDelayedArray = _imports.AnyDelayedArray
 
         # Conversion rules:
         # - we do not convert to matlab's own array types
@@ -34,7 +42,7 @@ class MatlabType:
         #   the matlab runtime;
         # - instead, we convert to python types that mimic matlab types.
         _from_any = partial(cls.from_any, **kwargs)
-        _from_runtime = kwargs.pop("_from_runtime", False)
+        _runtime = kwargs.pop("_runtime", None)
 
         if isinstance(other, MatlabType):
             if isinstance(other, AnyDelayedArray):
@@ -56,21 +64,21 @@ class MatlabType:
                 elif type__ == "structarray":
                     # MPython returns a list of dictionaries in data__
                     # and the array shape in size__.
-                    return Struct._from_runtime(other)
+                    return Struct._from_runtime(other, _runtime)
 
                 elif type__ == "cell":
                     # MPython returns a list of dictionaries in data__
                     # and the array shape in size__.
-                    return Cell._from_runtime(other)
+                    return Cell._from_runtime(other, _runtime)
 
                 elif type__ == "object":
                     # MPython returns the object's fields serialized
                     # in a dictionary.
-                    return MatlabClass._from_runtime(other)
+                    return MatlabClass._from_runtime(other, _runtime)
 
                 elif type__ == "sparse":
                     # MPython returns the coordinates and values in a dict.
-                    return SparseArray._from_runtime(other)
+                    return SparseArray._from_runtime(other, _runtime)
 
                 elif type__ == "char":
                     # Character array that is not a row vector
@@ -82,26 +90,28 @@ class MatlabType:
                     size = size[:-1] + [1]
                     other["type__"] = "cell"
                     other["size__"] = np.asarray([size])
-                    return Cell._from_runtime(other)
+                    return Cell._from_runtime(other, _runtime)
 
                 else:
                     raise ValueError("Don't know what to do with type", type__)
 
             else:
-                other = type(other)(zip(other.keys(), map(_from_any, other.values())))
+                other = type(other)(
+                    zip(other.keys(), map(_from_any, other.values()))
+                )
                 return Struct.from_any(other)
 
         if isinstance(other, (list, tuple, set)):
             # nested tuples are cells of cells, not cell arrays
-            if _from_runtime:
-                return Cell._from_runtime(other)
+            if _runtime:
+                return Cell._from_runtime(other, _runtime)
             else:
                 return Cell.from_any(other)
 
         if isinstance(other, (np.ndarray, int, float, complex, bool)):
             # [array of] numbers -> Array
-            if _from_runtime:
-                return Array._from_runtime(other)
+            if _runtime:
+                return Array._from_runtime(other, _runtime)
             else:
                 return Array.from_any(other)
 
@@ -117,20 +127,20 @@ class MatlabType:
 
         matlab = _import_matlab()
         if matlab and isinstance(other, matlab.object):
-            return MatlabFunction.from_any(other)
+            return MatlabFunction._from_runtime(other, _runtime)
 
         if type(other) in _matlab_array_types():
-            return Array._from_runtime(other)
+            return Array._from_runtime(other, _runtime)
 
         if hasattr(other, "__iter__"):
             # Iterable -> let's try to make it a cell
-            return cls.from_any(list(other), _from_runtime=_from_runtime)
+            return cls.from_any(list(other), _runtime=_runtime)
 
         raise TypeError(f"Cannot convert {type(other)} into a matlab object.")
 
     @classmethod
-    def _from_runtime(cls, obj):
-        return cls.from_any(obj, _from_runtime=True)
+    def _from_runtime(cls, obj, runtime):
+        return cls.from_any(obj, _runtime=runtime)
 
     @classmethod
     def _to_runtime(cls, obj):
@@ -162,8 +172,7 @@ class MatlabType:
             return obj
 
         elif sparse and isinstance(obj, sparse.sparray):
-            from .SparseArray import SparseArray
-
+            SparseArray = _imports.SparseArray
             return SparseArray.from_any(obj)._as_runtime()
 
         else:
@@ -192,14 +201,20 @@ class AnyMatlabArray(MatlabType):
 
     @property
     def as_num(self):
-        raise TypeError(f"Cannot interpret a {type(self).__name__} as a numeric array")
+        raise TypeError(
+            f"Cannot interpret a {type(self).__name__} as a numeric array"
+        )
 
     @property
     def as_cell(self):
-        raise TypeError(f"Cannot interpret a {type(self).__name__} as a cell")
+        raise TypeError(
+            f"Cannot interpret a {type(self).__name__} as a cell"
+        )
 
     @property
     def as_struct(self):
-        raise TypeError(f"Cannot interpret a {type(self).__name__} as a struct")
+        raise TypeError(
+            f"Cannot interpret a {type(self).__name__} as a struct"
+        )
 
     # TODO: `as_obj` for object arrays?

--- a/mpython/matlab_class.py
+++ b/mpython/matlab_class.py
@@ -6,14 +6,30 @@ from .core import MatlabType
 
 
 class MatlabClass(MatlabType):
+    """
+    Base class for wrapped MATLAB classes.
+
+    The MATLAB package wrapped by mpython must define its own inheriting
+    class that points to an appropriate runtime.
+
+    Example
+    -------
+    ```python
+    class MyPackageRuntimeMixin:
+        @classmethod
+        def _runtime(cls):
+            return MyPackageRuntime
+
+    class MyPackageClass(MyPackageRuntimeMixin, MatlabClass):
+        ...
+    ```
+    """
     _subclasses = dict()
 
     def __new__(cls, *args, _objdict=None, **kwargs):
         if _objdict is None:
             if cls.__name__ in MatlabClass._subclasses.keys():
-                from .runtime import Runtime
-
-                obj = Runtime.call(cls.__name__, *args, **kwargs)
+                obj = cls._runtime().call(cls.__name__, *args, **kwargs)
             else:
                 obj = super().__new__(cls)
         else:
@@ -41,7 +57,7 @@ class MatlabClass(MatlabType):
         return other
 
     @classmethod
-    def _from_runtime(cls, objdict):
+    def _from_runtime(cls, objdict, runtime=None):
         if objdict["class__"] in MatlabClass._subclasses.keys():
             obj = MatlabClass._subclasses[objdict["class__"]](_objdict=objdict)
         else:
@@ -91,18 +107,17 @@ class MatlabClass(MatlabType):
         # FIXME: This should not need to call matlab
         try:
             return tuple(
-                self._process_index(i, k + 1, len(ind)) for k, i in enumerate(ind)
+                self._process_index(i, k + 1, len(ind))
+                for k, i in enumerate(ind)
             )
         except TypeError:
             pass
 
-        from .runtime import Runtime
-
         if not hasattr(self, "__endfn"):
-            self.__endfn = Runtime.call("str2func", "end")
+            self.__endfn = self._Runtime.call("str2func", "end")
 
         def end():
-            return Runtime.call(self.__endfn, self._as_runtime(), k, n)
+            return self._runtime().call(self.__endfn, self._as_runtime(), k, n)
 
         if isinstance(ind, int):
             if ind >= 0:

--- a/mpython/matlab_function.py
+++ b/mpython/matlab_function.py
@@ -6,6 +6,8 @@ class MatlabFunction(MatlabType):
     """
     Wrapper for matlab function handles.
 
+    End users should not have to instantiate such objects themselves.
+
     Example
     -------
     ```python
@@ -14,7 +16,7 @@ class MatlabFunction(MatlabType):
     ```
     """
 
-    def __init__(self, matlab_object):
+    def __init__(self, matlab_object, runtime):
         super().__init__()
 
         matlab = _import_matlab()
@@ -22,21 +24,20 @@ class MatlabFunction(MatlabType):
             raise TypeError("Expected a matlab.object")
 
         self._matlab_object = matlab_object
+        self._runtime = runtime
 
     def _as_runtime(self):
         return self._matlab_object
 
     @classmethod
-    def _from_runtime(cls, other):
-        return cls(other)
+    def _from_runtime(cls, other, runtime):
+        return cls(other, runtime)
 
     @classmethod
-    def from_any(cls, other):
+    def from_any(cls, other, runtime=None):
         if isinstance(other, MatlabFunction):
             return other
-        return cls._from_runtime(other)
+        return cls._from_runtime(other, runtime)
 
     def __call__(self, *args, **kwargs):
-        from .runtime import Runtime
-
-        return Runtime.call(self._matlab_object, *args, **kwargs)
+        return self._runtime.call(self._matlab_object, *args, **kwargs)


### PR DESCRIPTION
See #3

This PR removes the explicit import of `spm._spm` and instead lets the wrapped package (in our case, spm-python) implement its own `Runtime` class. Something like:

```python
# in: spm/__wrapper__.py
from mpython.runtime import Runtime as RuntimeBase

class Runtime(RuntimeBase):
    @classmethod
    def _import_runtime(cls):
        import spm_runtime
        return spm_runtime
```

It also needs each of the `MatlabClass` children it implements to point to the correct runtime. It's a bit tricky if we don't want to mess with the `__init_subclass__` business implemented in `MatlabClass` but I think it can be done in a not too verbose way using a mixin:

```python
# in: spm/__wrapper__.py

class RuntimeMixin:
    @classmethod
    def _runtime(cls):
        return Runtime

# in: spm/nifti.py
from mpython.matlab_class import MatlabClass

class nifti(RuntimeMixin, MatlabClass):
    ...
```

I am leaving this as draft as it needs
- `spm-runtime` to be properly released and published to pypi
- `spm-python` and `mpython` to define the runtime and mixin described above

---

I've also replaced the local imports (used to break circular imports) with "delayed imports" using a magic class. The (only?) advantage is it allows to have all the imports listed at the top of the file like we're used to. See e.g.

https://github.com/MPython-Package-Factory/mpython-core/blob/ec0f3e5827427df8452acc7704b8f54aad739f39/mpython/core/base_types.py#L8-L15

---

Happy to discuss! (@johmedr )